### PR TITLE
Remove automatic action execution except cron

### DIFF
--- a/.github/workflows/make-and-upload-package.yml
+++ b/.github/workflows/make-and-upload-package.yml
@@ -5,18 +5,6 @@ on:
   schedule:
     - cron: '0 0,12 * * *'  # every day at midnight and noon (UTC)
 
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
-      - LICENSE.md
-      
-  pull_request:
-    paths-ignore: 
-      - README.md
-      - LICENSE.md
-
 # Allows manually triggering this script.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
I don't want the package generation to run on every PR. It might upload faulty packages before having been verified.