### PR TITLE
Replace DepotDownloader with SteamCMD

### DIFF
--- a/.github/workflows/make-and-upload-package.yml
+++ b/.github/workflows/make-and-upload-package.yml
@@ -13,11 +13,9 @@ on:
         type: boolean
 
 env:
-  # The commit hash of DepotDownloader to download and use in this script.
-  DEPOT_DOWNLOADER_COMMIT: 3143362d83b0f6753e48b50fa7e06735756b2361
   RIMWORLD_APP_ID: 294100
-  # Id of the logical set of files from which to download the Rimworld assemblies.
-  RIMWORLD_DEPOT_ID: 294104
+  # SteamCMD downloads RimWorld here by default.
+  RIMWORLD_ROOT_DIR: 'C:\hostedtoolcache\windows\steamcmd\latest\i386\steamapps\common\RimWorld'
 
 jobs:
   generate-package:
@@ -29,87 +27,38 @@ jobs:
         # We check the following beta branches on Steam for updates.
         branch: [public, unstable]
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-
+    
       - name: Check out repository
         uses: actions/checkout@v3
-
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v3.2.0
-        with:
-          dotnet-version: 7.0.x
-        env:
-          DOTNET_NOLOGO: true
-          DOTNET_CLI_TELEMETRY_OPTOUT: true
           
+      - name: Setup SteamCMD
+        uses: CyberAndrii/setup-steamcmd@v1.1.5
+        
       - name: Set up NuGet
         uses: NuGet/setup-nuget@v1.2.0
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          
-        # DepotDownloader is retrieved from cache, if possible.
-      - name: Try set up DepotDownloader from cache
-        id: cache-depot-downloader
-        uses: actions/cache@v3.3.1
-        with:
-          path: /usr/local/bin/depot-downloader
-          key: depot-downloader-${{ env.DEPOT_DOWNLOADER_COMMIT }}
-          
-        # Installs DepotDownloader, unless it's available in the cache since a previous run.
-      - name: Set up DepotDownloader
-        run: |
-          sudo git clone --no-checkout https://github.com/SteamRE/DepotDownloader.git .
-          sudo git -c advice.detachedHead=false checkout ${{ env.DEPOT_DOWNLOADER_COMMIT }}
-          sudo dotnet publish \
-            DepotDownloader/DepotDownloader.csproj \
-            --configuration Release \
-            --output /usr/local/bin \
-            --runtime linux-x64 \
-            --self-contained \
-            /p:DebugType=embedded \
-            /p:PublishReadyToRun=true \
-            /p:PublishSingleFile=true \
-            /p:AssemblyName=depot-downloader
-        working-directory: /usr/local/src
-        if: steps.cache-depot-downloader.outputs.cache-hit != 'true'
         
       - name: Set up Refasmer
         run: dotnet tool install --global JetBrains.Refasmer.CliTool --version 1.0.33
-
-        # Specifically downloads the Version.txt and managed assemblies for Rimworld.
+      
       - name: Download Rimworld
-        run: |
-          filelist="$(mktemp)"
-          echo "Version.txt" > $filelist
-          echo "regex:^RimWorldWin64_Data\/Managed\/.*dll$" >> $filelist
-          echo "Downloading Version.txt and all managed assemblies of Rimworld from Steam"
-          depot-downloader \
-            -app ${{ env.RIMWORLD_APP_ID }} \
-            -depot ${{ env.RIMWORLD_DEPOT_ID }} \
-            -filelist $filelist \
-            -beta ${{ matrix.branch }} \
-            -username ${{ secrets.STEAM_USERNAME }} \
-            -password ${{ secrets.STEAM_PASSWORD }} \
-            -dir ${{ github.workspace }}
-        
+        run: steamcmd +login ${{ secrets.STEAM_USERNAME }} ${{ secrets.STEAM_PASSWORD }} +app_update ${{ env.RIMWORLD_APP_ID }} +quit
+
       - name: Generate reference assemblies
-        run: refasmer -v --all -O ${{ github.workspace }}/package/ref/net472 $(ls) 
-        working-directory: ./RimWorldWin64_Data/Managed
-        
-        # Resolves the version of the package from Rimworld's Version.txt, and appends '-beta' if from a beta-branch.
-        # Packs the package.
+        run: refasmer -v --all -O ${{ github.workspace }}\package\ref\net472 $(Get-ChildItem -Name)
+        working-directory: ${{ env.RIMWORLD_ROOT_DIR }}\RimWorldWin64_Data\Managed
+
       - name: Assemble NuGet package
         run: |
-          version="$(cat ${{ github.workspace }}/Version.txt | cut -d' ' -f1)"
-          if [ ${{ matrix.branch }} != public ]; then
-            version=$version-beta
-          fi
-          echo "Rimworld version: $version"
-          year=$(date '+%Y')
-          nuget pack -Version $version -Properties year=$year -NoPackageAnalysis
+          $Version = $(cat ${{ env.RIMWORLD_ROOT_DIR }}\Version.txt).split()[0]
+          $Version = If ("${{ matrix.branch }}" -eq "public") { $Version } Else { "$Version-beta" }
+          $Year = Get-Date -Format "yyyy"
+          nuget pack -Version $Version -Properties year=$Year -NoPackageAnalysis
         working-directory: ./package
-
+        
         # Uploads the package as a GitHub artifact.
       - name: Upload GitHub artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/make-and-upload-package.yml
+++ b/.github/workflows/make-and-upload-package.yml
@@ -45,7 +45,7 @@ jobs:
         run: dotnet tool install --global JetBrains.Refasmer.CliTool --version 1.0.33
       
       - name: Download Rimworld
-        run: steamcmd +login ${{ secrets.STEAM_USERNAME }} ${{ secrets.STEAM_PASSWORD }} +app_update ${{ env.RIMWORLD_APP_ID }} +quit
+        run: steamcmd +login ${{ secrets.STEAM_USERNAME }} ${{ secrets.STEAM_PASSWORD }} +app_update ${{ env.RIMWORLD_APP_ID }} -beta ${{ matrix.branch }} +quit
 
       - name: Generate reference assemblies
         run: refasmer -v --all -O ${{ github.workspace }}\package\ref\net472 $(Get-ChildItem -Name)


### PR DESCRIPTION
Steam recently started requiring downloaders to explicitly provide ManifestIDs for downloads.
RimRef has only ever just provided the AppID, DepotID and branch to DepotDownloader, which has resolved to downloading the files from the latest manifest.
Not given a ManifestID, DepotDownloader now returns an error instead. The ManifestID could update, so RimRef should not hardcode it in the packaging script, and there is no simple way of resolving it for subsequent use with DepotDownloader, at least not that I know of.

Therefore, DepotDowloader is being replaced with SteamCMD, which is an official tool from Valve to interact with its depots. The reason DepotDownloader was used at all was its ability to specify exactly which files to download from a depot, like `Version.txt` and the assemblies in `Managed`. SteamCMD does not have that kind of granularity, which means each execution will have a larger download size, but I guess that's an acceptable tradeoff.